### PR TITLE
Ignore the declared factory names in the generated implementation.

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/keys.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/keys.kt
@@ -64,13 +64,16 @@ internal data class BindingKey(
 
   enum class Use { PROVIDED, ASSISTED }
 
-  fun providerType(): TypeName {
-    val type = ParameterizedTypeName.get(PROVIDER, TypeName.get(key.type))
-    key.qualifier?.let {
-      return type.annotated(AnnotationSpec.get(it))
-    }
-    return type
-  }
+  val type: TypeName = TypeName.get(key.type)
+
+  val providerType: TypeName
+      get() {
+        val type = ParameterizedTypeName.get(PROVIDER, type)
+        key.qualifier?.let {
+          return type.annotated(AnnotationSpec.get(it))
+        }
+        return type
+      }
 
   fun bindingResolveCode(): CodeBlock = when (use) {
     PROVIDED -> CodeBlock.of("\$N.get()", name)

--- a/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
+++ b/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
@@ -69,6 +69,52 @@ class AssistedInjectProcessorTest {
         .generatesSources(expected)
   }
 
+  @Test fun factoryParameterNameIsNotUsedInTheImpl() {
+    val input = JavaFileObjects.forSourceString("test.Test", """
+      package test;
+
+      import com.squareup.inject.assisted.Assisted;
+
+      class Test {
+        Test(Long foo, @Assisted String bar) {}
+
+        @Assisted.Factory
+        interface Factory {
+          Test create(String blah);
+        }
+      }
+    """)
+
+    val expected = JavaFileObjects.forSourceString("test.Test_AssistedFactory", """
+      package test;
+
+      import java.lang.Long;
+      import java.lang.Override;
+      import java.lang.String;
+      import javax.inject.Inject;
+      import javax.inject.Provider;
+
+      public final class Test_AssistedFactory implements Test.Factory {
+        private final Provider<Long> foo;
+
+        @Inject public Test_AssistedFactory(Provider<Long> foo) {
+          this.foo = foo;
+        }
+
+        @Override public Test create(String bar) {
+          return new Test(foo.get(), bar);
+        }
+      }
+    """)
+
+    assertAbout(javaSource())
+        .that(input)
+        .processedWith(AssistedInjectProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected)
+  }
+
   @Test fun providedAndAssistedSameType() {
     val input = JavaFileObjects.forSourceString("test.Test", """
       package test;


### PR DESCRIPTION
This works around a bug in kapt where the names are not retained, but it also uses a single source of truth for the parameter name and then their use in the method body.