### PR TITLE
Remove ViewFactory generics, don't generate covariant return type

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectRequest.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectRequest.kt
@@ -51,7 +51,7 @@ data class AssistedInjectRequest(
         .addMethod(MethodSpec.methodBuilder(factoryMethod.simpleName.toString())
             .addAnnotation(Override::class.java)
             .addModifiers(PUBLIC)
-            .returns(typeName)
+            .returns(TypeName.get(factoryMethod.returnType))
             .apply {
               if (typeName is ParameterizedTypeName) {
                 addTypeVariables(typeName.typeArguments.filterIsInstance<TypeVariableName>())

--- a/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
+++ b/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
@@ -764,10 +764,35 @@ class AssistedInjectProcessorTest {
       interface TestBase {}
     """)
 
+    // Ensure a covariant return type is not used which creates two methods in the bytecode.
+    val expected = JavaFileObjects.forSourceString("test.Test_AssistedFactory", """
+      package test;
+
+      import java.lang.Long;
+      import java.lang.Override;
+      import java.lang.String;
+      import javax.inject.Inject;
+      import javax.inject.Provider;
+
+      public final class Test_AssistedFactory implements Test.Factory {
+        private final Provider<Long> foo;
+
+        @Inject public Test_AssistedFactory(Provider<Long> foo) {
+          this.foo = foo;
+        }
+
+        @Override public TestBase create(String bar) {
+          return new Test(foo.get(), bar);
+        }
+      }
+    """)
+
     assertAbout(javaSource())
         .that(input)
         .processedWith(AssistedInjectProcessor())
         .compilesWithoutError()
+        .and()
+        .generatesSources(expected)
   }
 
 

--- a/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
+++ b/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
@@ -11,10 +11,7 @@ import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.ParameterizedTypeName
-import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
-import com.squareup.javapoet.WildcardTypeName
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
@@ -81,8 +78,8 @@ class InflationInjectProcessor : AbstractProcessor() {
                 .addAnnotation(AnnotationSpec.builder(STRING_KEY)
                     .addMember("value", "\$S", type.qualifiedName.toString())
                     .build())
-                .returns(VIEW_FACTORY_WILDCARD)
                 .addModifiers(ABSTRACT)
+                .returns(ViewFactory::class.java)
                 .addParameter(request.generatedClassName, "factory")
                 .build())
 
@@ -106,7 +103,4 @@ private val MODULE = ClassName.get("dagger", "Module")
 private val BINDS = ClassName.get("dagger", "Binds")
 private val INTO_MAP = ClassName.get("dagger.multibindings", "IntoMap")
 private val STRING_KEY = ClassName.get("dagger.multibindings", "StringKey")
-private val VIEW_FACTORY_WILDCARD = ParameterizedTypeName.get(
-    ClassName.get(ViewFactory::class.java),
-    WildcardTypeName.subtypeOf(TypeName.OBJECT))
 private fun ClassName.bindMethodName() = "bind_" + reflectionName().replace('.', '_')

--- a/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
+++ b/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
@@ -41,6 +41,7 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.util.AttributeSet;
+      import android.view.View;
       import com.squareup.inject.inflation.ViewFactory;
       import java.lang.Long;
       import java.lang.Override;
@@ -54,7 +55,7 @@ class InflationInjectProcessorTest {
           this.foo = foo;
         }
 
-        @Override public TestView create(Context context, AttributeSet attrs) {
+        @Override public View create(Context context, AttributeSet attrs) {
           return new TestView(context, attrs, foo.get());
         }
       }
@@ -75,7 +76,7 @@ class InflationInjectProcessorTest {
         @Binds
         @IntoMap
         @StringKey("test.TestView")
-        abstract ViewFactory<?> bind_test_TestView(TestView_AssistedFactory factory);
+        abstract ViewFactory bind_test_TestView(TestView_AssistedFactory factory);
       }
     """)
 
@@ -120,6 +121,7 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.util.AttributeSet;
+      import android.view.View;
       import com.squareup.inject.inflation.ViewFactory;
       import java.lang.Long;
       import java.lang.Override;
@@ -133,7 +135,7 @@ class InflationInjectProcessorTest {
           this.foo = foo;
         }
 
-        @Override public TestView create(Context context, AttributeSet attrs) {
+        @Override public View create(Context context, AttributeSet attrs) {
           return new TestView(foo.get(), context, attrs);
         }
       }
@@ -181,6 +183,7 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.util.AttributeSet;
+      import android.view.View;
       import com.squareup.inject.inflation.ViewFactory;
       import java.lang.Long;
       import java.lang.Override;
@@ -194,7 +197,7 @@ class InflationInjectProcessorTest {
           this.foo = foo;
         }
 
-        @Override public TestView create(Context context, AttributeSet attrs) {
+        @Override public View create(Context context, AttributeSet attrs) {
           return new TestView(attrs, context, foo.get());
         }
       }
@@ -268,6 +271,7 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.util.AttributeSet;
+      import android.view.View;
       import com.squareup.inject.inflation.ViewFactory;
       import java.lang.Long;
       import java.lang.Override;
@@ -281,7 +285,7 @@ class InflationInjectProcessorTest {
           this.foo = foo;
         }
 
-        @Override public TestView create(Context context, AttributeSet attrs) {
+        @Override public View create(Context context, AttributeSet attrs) {
           return new TestView(context, attrs, foo.get());
         }
       }

--- a/inflation-inject-sample/src/main/java/com/example/ViewModule.java
+++ b/inflation-inject-sample/src/main/java/com/example/ViewModule.java
@@ -11,7 +11,7 @@ import java.util.Map;
 @Module(includes = InflationInject_ViewModule.class)
 public abstract class ViewModule {
   @Provides
-  static DaggerLayoutInflaterFactory provide(Map<String, ViewFactory<?>> factories) {
+  static DaggerLayoutInflaterFactory provide(Map<String, ViewFactory> factories) {
     return new DaggerLayoutInflaterFactory(factories, null);
   }
 }

--- a/inflation-inject/src/main/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactory.java
+++ b/inflation-inject/src/main/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactory.java
@@ -9,12 +9,12 @@ import androidx.annotation.Nullable;
 import java.util.Map;
 
 public final class DaggerLayoutInflaterFactory implements LayoutInflater.Factory2 {
-  private final Map<String, ViewFactory<?>> factories;
+  private final Map<String, ViewFactory> factories;
   private final @Nullable LayoutInflater.Factory delegate;
   private final @Nullable LayoutInflater.Factory2 delegate2;
 
   @SuppressWarnings("ConstantConditions") // Validating API invariants.
-  public DaggerLayoutInflaterFactory(@NonNull Map<String, ViewFactory<?>> factories,
+  public DaggerLayoutInflaterFactory(@NonNull Map<String, ViewFactory> factories,
       @Nullable LayoutInflater.Factory delegate) {
     if (factories == null) throw new NullPointerException("factories == null");
     this.factories = factories;
@@ -23,7 +23,7 @@ public final class DaggerLayoutInflaterFactory implements LayoutInflater.Factory
   }
 
   @SuppressWarnings("ConstantConditions") // Validating API invariants.
-  public DaggerLayoutInflaterFactory(@NonNull Map<String, ViewFactory<?>> factories,
+  public DaggerLayoutInflaterFactory(@NonNull Map<String, ViewFactory> factories,
       @Nullable LayoutInflater.Factory2 delegate) {
     if (factories == null) throw new NullPointerException("factories == null");
     this.factories = factories;
@@ -33,7 +33,7 @@ public final class DaggerLayoutInflaterFactory implements LayoutInflater.Factory
 
   @Nullable @Override public View onCreateView(@NonNull String name, @NonNull Context context,
       @Nullable AttributeSet attrs) {
-    ViewFactory<?> factory = factories.get(name);
+    ViewFactory factory = factories.get(name);
     if (factory != null) {
       return factory.create(context, attrs);
     }
@@ -46,7 +46,7 @@ public final class DaggerLayoutInflaterFactory implements LayoutInflater.Factory
   @Nullable
   @Override
   public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
-    ViewFactory<?> factory = factories.get(name);
+    ViewFactory factory = factories.get(name);
     if (factory != null) {
       return factory.create(context, attrs);
     }

--- a/inflation-inject/src/main/java/com/squareup/inject/inflation/ViewFactory.java
+++ b/inflation-inject/src/main/java/com/squareup/inject/inflation/ViewFactory.java
@@ -6,7 +6,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public interface ViewFactory<V extends View> {
+public interface ViewFactory {
   @NonNull
-  V create(@NonNull Context context, @Nullable AttributeSet attrs);
+  View create(@NonNull Context context, @Nullable AttributeSet attrs);
 }

--- a/inflation-inject/src/test/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactory2Test.kt
+++ b/inflation-inject/src/test/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactory2Test.kt
@@ -27,7 +27,7 @@ class DaggerLayoutInflaterFactory2Test {
 
   @Test fun viewFactoryMissingWithDelegateDelegates() {
     val expected = View(context)
-    val factories = emptyMap<String, ViewFactory<*>>()
+    val factories = emptyMap<String, ViewFactory>()
     val delegate = object : LayoutInflater.Factory2 {
       override fun onCreateView(parent: View?, name: String, context: Context,
           attrs: AttributeSet?) = expected
@@ -43,7 +43,7 @@ class DaggerLayoutInflaterFactory2Test {
   }
 
   @Test fun viewFactoryMissingWithoutDelegateReturnsNull() {
-    val factories = emptyMap<String, ViewFactory<*>>()
+    val factories = emptyMap<String, ViewFactory>()
     val inflater = DaggerLayoutInflaterFactory(factories, null)
     val actual = inflater.onCreateView(null, "com.example.View", context, null)
     assertNull(actual)

--- a/inflation-inject/src/test/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactoryTest.kt
+++ b/inflation-inject/src/test/java/com/squareup/inject/inflation/DaggerLayoutInflaterFactoryTest.kt
@@ -27,7 +27,7 @@ class DaggerLayoutInflaterFactoryTest {
 
   @Test fun viewFactoryMissingWithDelegateDelegates() {
     val expected = View(context)
-    val factories = emptyMap<String, ViewFactory<*>>()
+    val factories = emptyMap<String, ViewFactory>()
     val delegate = LayoutInflater.Factory { _, _, _ -> expected }
     val inflater = DaggerLayoutInflaterFactory(factories, delegate)
     val actual = inflater.onCreateView("com.example.View", context, null)
@@ -35,7 +35,7 @@ class DaggerLayoutInflaterFactoryTest {
   }
 
   @Test fun viewFactoryMissingWithoutDelegateReturnsNull() {
-    val factories = emptyMap<String, ViewFactory<*>>()
+    val factories = emptyMap<String, ViewFactory>()
     val inflater = DaggerLayoutInflaterFactory(factories, null)
     val actual = inflater.onCreateView("com.example.View", context, null)
     assertNull(actual)


### PR DESCRIPTION
The generics of ViewFactory served no real purpose since the consumer only cares about View. Removing this eliminates a second method reference from being generated by javac for view factories.

When a factory method return type is a supertype of the enclosing type, do not generate a covariant return. Removing this eliminates a second method reference from being genrated by javac.