### PR TITLE
Actually check and test duplicate keys

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
@@ -19,7 +19,6 @@ import com.google.auto.common.MoreTypes
 import com.google.auto.service.AutoService
 import com.squareup.inject.assisted.AssistedInject
 import com.squareup.inject.assisted.processor.internal.cast
-import com.squareup.inject.assisted.processor.internal.duplicates
 import com.squareup.inject.assisted.processor.internal.findElementsAnnotatedWith
 import com.squareup.inject.assisted.processor.internal.hasAnnotation
 import com.squareup.javapoet.ClassName
@@ -156,11 +155,11 @@ class AssistedInjectProcessor : AbstractProcessor() {
       throw StopProcessingException(
           "Assisted injection requires at least one non-@Assisted parameter.", method)
     }
-    val duplicateKeys = providedKeys.duplicates()
-    if (duplicateKeys.isNotEmpty()) {
+    val duplicates = providedKeys.groupBy { it.key }.filterValues { it.size > 1 }.values.flatten()
+    if (duplicates.isNotEmpty()) {
       throw StopProcessingException(
           "Duplicate non-@Assisted parameters declared. Forget a qualifier annotation?"
-              + duplicateKeys.toSet().joinToString("\n * ", prefix = "\n * "),
+              + duplicates.joinToString("\n * ", prefix = "\n * "),
           method)
     }
   }
@@ -170,11 +169,11 @@ class AssistedInjectProcessor : AbstractProcessor() {
       throw StopProcessingException(
           "Assisted injection requires at least one @Assisted parameter.", method)
     }
-    val duplicateKeys = assistedKeys.duplicates()
-    if (duplicateKeys.isNotEmpty()) {
+    val duplicates = assistedKeys.groupBy { it.key }.filterValues { it.size > 1 }.values.flatten()
+    if (duplicates.isNotEmpty()) {
       throw StopProcessingException(
           "Duplicate @Assisted parameters declared. Forget a qualifier annotation?"
-              + duplicateKeys.toSet().joinToString("\n * ", prefix = "\n * "),
+              + duplicates.joinToString("\n * ", prefix = "\n * "),
           method)
     }
   }

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/ParameterKey.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/ParameterKey.kt
@@ -25,7 +25,9 @@ data class ParameterKey(
     /** True when fulfilled by the caller. Otherwise fulfilled by a JSR 330 provider. */
     val isAssisted: Boolean,
     val name: String
-)
+) {
+  override fun toString() = (if (isAssisted) "@Assisted " else "") + "$key $name"
+}
 
 fun VariableElement.asParameterKey() =
     ParameterKey(asKey(), hasAnnotation<Assisted>(), simpleName.toString())

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/utils.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/utils.kt
@@ -36,10 +36,6 @@ fun AnnotatedConstruct.hasAnnotation(qualifiedName: String) = annotationMirrors
 @Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
 inline fun <T> Iterable<*>.cast() = map { it as T }
 
-/** Return a list of duplicated items in the [Iterable]. */
-// TODO https://youtrack.jetbrains.com/issue/KT-18405
-fun <T> Iterable<T>.duplicates(): List<T> = filterNotTo(mutableListOf(), mutableSetOf<T>()::add)
-
 inline fun <T : Any, I> T.applyEach(items: Iterable<I>, func: T.(I) -> Unit): T {
   items.forEach { item -> func(item) }
   return this


### PR DESCRIPTION
Prior to this change we were checking for duplicate parameter keys (which are impossible as javac prevents them) where we needed to be checking for duplicate keys.