### PR TITLE
Allow assisted parameters of the same type

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/DependencyRequest.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/DependencyRequest.kt
@@ -21,13 +21,15 @@ import javax.lang.model.element.VariableElement
 
 /** Associates a [Key] with its desired use as assisted or not. */
 data class DependencyRequest(
-  val key: Key,
+  val namedKey: NamedKey,
   /** True when fulfilled by the caller. Otherwise fulfilled by a JSR 330 provider. */
-  val isAssisted: Boolean,
-  val name: String
+  val isAssisted: Boolean
 ) {
+  val key get() = namedKey.key
+  val name get() = namedKey.name
+
   override fun toString() = (if (isAssisted) "@Assisted " else "") + "$key $name"
 }
 
 fun VariableElement.asDependencyRequest() =
-    DependencyRequest(asKey(), hasAnnotation<Assisted>(), simpleName.toString())
+    DependencyRequest(asNamedKey(), hasAnnotation<Assisted>())

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/Key.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/Key.kt
@@ -20,15 +20,18 @@ import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.TypeName
 import javax.lang.model.element.VariableElement
 
+private val keyComparator = compareBy<Key>({ it.type.toString() }, { it.qualifier == null })
+
 /** Represents a type and an optional qualifier annotation for a binding. */
 data class Key(
   val type: TypeName,
   val qualifier: AnnotationSpec? = null
-) {
+) : Comparable<Key> {
   override fun toString() = qualifier?.let { "$it $type" } ?: type.toString()
+  override fun compareTo(other: Key) = keyComparator.compare(this, other)
 }
 
-/** Create from this type and any qualifier annotation. */
+/** Create a [Key] from this type and any qualifier annotation. */
 fun VariableElement.asKey() = Key(TypeName.get(asType()),
     annotationMirrors.find {
       it.annotationType.asElement().hasAnnotation("javax.inject.Qualifier")

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/NamedKey.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/NamedKey.kt
@@ -1,0 +1,17 @@
+package com.squareup.inject.assisted.processor
+
+import javax.lang.model.element.VariableElement
+
+private val namedKeyComparator = compareBy<NamedKey>({ it.key }, { it.name })
+
+/** Represents a [Key] associated with a name. */
+data class NamedKey(
+  val key: Key,
+  val name: String
+) : Comparable<NamedKey> {
+  override fun toString() = "$key $name"
+  override fun compareTo(other: NamedKey) = namedKeyComparator.compare(this, other)
+}
+
+/** Create a [NamedKey] from this type, any qualifier annotation, and the name. */
+fun VariableElement.asNamedKey() = NamedKey(asKey(), simpleName.toString())

--- a/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
+++ b/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
@@ -3,6 +3,7 @@ package com.squareup.inject.inflation.processor
 import com.google.auto.service.AutoService
 import com.squareup.inject.assisted.processor.AssistedInjection
 import com.squareup.inject.assisted.processor.Key
+import com.squareup.inject.assisted.processor.NamedKey
 import com.squareup.inject.assisted.processor.asDependencyRequest
 import com.squareup.inject.assisted.processor.internal.MirrorValue
 import com.squareup.inject.assisted.processor.internal.applyEach
@@ -185,7 +186,7 @@ class InflationInjectProcessor : AbstractProcessor() {
 
     val requests = targetConstructor.parameters.map { it.asDependencyRequest() }
     val (assistedRequests, providedRequests) = requests.partition { it.isAssisted }
-    val assistedKeys = assistedRequests.map { it.key }
+    val assistedKeys = assistedRequests.map { it.namedKey }
     if (assistedKeys.toSet() != FACTORY_KEYS.toSet()) {
       error("""
         Inflation injection requires Context and AttributeSet @Assisted parameters.
@@ -299,5 +300,5 @@ class InflationInjectProcessor : AbstractProcessor() {
 private val VIEW = ClassName.get("android.view", "View")
 private val FACTORY = ClassName.get(ViewFactory::class.java)
 private val FACTORY_KEYS = listOf(
-    Key(ClassName.get("android.content", "Context")),
-    Key(ClassName.get("android.util", "AttributeSet")))
+    NamedKey(Key(ClassName.get("android.content", "Context")), "context"),
+    NamedKey(Key(ClassName.get("android.util", "AttributeSet")), "attrs"))

--- a/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
+++ b/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
@@ -195,6 +195,70 @@ class InflationInjectProcessorTest {
         .generatesSources(expectedFactory)
   }
 
+  @Test fun differentNameContext() {
+    val inputView = JavaFileObjects.forSourceString("test.TestView", """
+      package test;
+
+      import android.content.Context;
+      import android.util.AttributeSet;
+      import android.view.View;
+      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.InflationInject;
+
+      class TestView extends View {
+        @InflationInject
+        TestView(@Assisted Context c, @Assisted AttributeSet attrs, Long foo) {
+          super(context, attrs);
+        }
+      }
+    """)
+
+    assertAbout(javaSource())
+        .that(inputView)
+        .processedWith(InflationInjectProcessor())
+        .failsToCompile()
+        .withErrorContaining("""
+          Inflation injection requires Context and AttributeSet @Assisted parameters.
+              Found:
+                [android.content.Context c, android.util.AttributeSet attrs]
+              Expected:
+                [android.content.Context context, android.util.AttributeSet attrs]
+          """.trimIndent())
+        .`in`(inputView).onLine(12)
+  }
+
+  @Test fun differentNameAttributeSet() {
+    val inputView = JavaFileObjects.forSourceString("test.TestView", """
+      package test;
+
+      import android.content.Context;
+      import android.util.AttributeSet;
+      import android.view.View;
+      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.InflationInject;
+
+      class TestView extends View {
+        @InflationInject
+        TestView(@Assisted Context context, @Assisted AttributeSet a, Long foo) {
+          super(context, attrs);
+        }
+      }
+    """)
+
+    assertAbout(javaSource())
+        .that(inputView)
+        .processedWith(InflationInjectProcessor())
+        .failsToCompile()
+        .withErrorContaining("""
+          Inflation injection requires Context and AttributeSet @Assisted parameters.
+              Found:
+                [android.content.Context context, android.util.AttributeSet a]
+              Expected:
+                [android.content.Context context, android.util.AttributeSet attrs]
+          """.trimIndent())
+        .`in`(inputView).onLine(12)
+  }
+
   @Test fun contextAndAttributeSetSwapped() {
     val inputView = JavaFileObjects.forSourceString("test.TestView", """
       package test;
@@ -438,7 +502,7 @@ class InflationInjectProcessorTest {
               Found:
                 []
               Expected:
-                [android.content.Context, android.util.AttributeSet]
+                [android.content.Context context, android.util.AttributeSet attrs]
           """.trimIndent())
         .`in`(inputView).onLine(9)
   }
@@ -468,9 +532,9 @@ class InflationInjectProcessorTest {
         .withErrorContaining("""
           Inflation injection requires Context and AttributeSet @Assisted parameters.
               Found:
-                [android.content.Context, android.util.AttributeSet, java.lang.String]
+                [android.content.Context context, android.util.AttributeSet attrs, java.lang.String hey]
               Expected:
-                [android.content.Context, android.util.AttributeSet]
+                [android.content.Context context, android.util.AttributeSet attrs]
           """.trimIndent())
         .`in`(inputView).onLine(12)
   }
@@ -499,9 +563,9 @@ class InflationInjectProcessorTest {
         .withErrorContaining("""
           Inflation injection requires Context and AttributeSet @Assisted parameters.
               Found:
-                [android.util.AttributeSet]
+                [android.util.AttributeSet attrs]
               Expected:
-                [android.content.Context, android.util.AttributeSet]
+                [android.content.Context context, android.util.AttributeSet attrs]
           """.trimIndent())
         .`in`(inputView).onLine(11)
   }
@@ -530,9 +594,9 @@ class InflationInjectProcessorTest {
         .withErrorContaining("""
           Inflation injection requires Context and AttributeSet @Assisted parameters.
               Found:
-                [android.content.Context]
+                [android.content.Context context]
               Expected:
-                [android.content.Context, android.util.AttributeSet]
+                [android.content.Context context, android.util.AttributeSet attrs]
           """.trimIndent())
         .`in`(inputView).onLine(11)
   }


### PR DESCRIPTION
This changes assisted validation to enforce that the parameter names of assisted types match those of the factory. This restriction is only for simplification of the internal code. If it becomes a problem we can relax the parameter name matching to only apply to assisted types which are duplicates.

Closes #46