### PR TITLE
Inflation injection only handles classes, not types

### DIFF
--- a/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
+++ b/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
@@ -260,7 +260,7 @@ class InflationInjectProcessor : AbstractProcessor() {
 
   private fun InflationModuleElements.toInflationInjectionModule(): InflationInjectionModule {
     val moduleName = moduleType.toClassName()
-    val inflationNames = inflationTypes.map { it.asType().toTypeName() }
+    val inflationNames = inflationTypes.map { it.toClassName() }
     val public = Modifier.PUBLIC in moduleType.modifiers
     val generatedAnnotation = createGeneratedAnnotation(elements)
     return InflationInjectionModule(moduleName, public, inflationNames, generatedAnnotation)


### PR DESCRIPTION
You cannot express anything for which a type would be needed in XML. Only raw classes. The factory should still support parameterized types, though, which it currently does not. A failing test case is included as ignored.

Additionally, nested types are specified using their reflection names (since they're looked up with Class.forName) and so the key needs to use the reflection name.

Refs #64