### PR TITLE
Add AppCompat Example that works with AssistedInject.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
       'compileTesting': 'com.google.testing.compile:compile-testing:0.15',
       'robolectric': 'org.robolectric:robolectric:4.0-alpha-3',
       'inject': 'javax.inject:javax.inject:1',
+      'appcompat': 'com.android.support:appcompat-v7:28.0.0',
       'android': 'com.google.android:android:4.1.1.4',
       'androidxAnnotations': 'androidx.annotation:annotation:1.0.0',
       'dexMemberList': 'com.jakewharton.dex:dex-member-list:3.2.1',

--- a/inflation-inject-sample/build.gradle
+++ b/inflation-inject-sample/build.gradle
@@ -44,6 +44,7 @@ android {
 dependencies {
   implementation deps.dagger
   annotationProcessor deps.daggerCompiler
+  implementation deps.appcompat
 
   implementation project(':inflation-inject')
   annotationProcessor project(':inflation-inject-processor')

--- a/inflation-inject-sample/src/main/AndroidManifest.xml
+++ b/inflation-inject-sample/src/main/AndroidManifest.xml
@@ -10,5 +10,9 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+
+    <activity android:name=".MainActivityAppCompat"
+              android:theme="@style/Theme.AppCompat" />
+
   </application>
 </manifest>

--- a/inflation-inject-sample/src/main/java/android/support/v7/app/MainActivityAppCompatDelegate.java
+++ b/inflation-inject-sample/src/main/java/android/support/v7/app/MainActivityAppCompatDelegate.java
@@ -1,0 +1,207 @@
+package android.support.v7.app;
+
+import com.squareup.inject.inflation.InflationInjectFactory;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.view.ActionMode;
+import android.support.v7.widget.Toolbar;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.MenuInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class MainActivityAppCompatDelegate extends AppCompatDelegate implements
+                                                                     LayoutInflater.Factory2 {
+
+    @NonNull
+    private final Context context;
+
+    @NonNull
+    private final AppCompatDelegate originalDelegate;
+
+    @NonNull
+    private final InflationInjectFactory inflationInjectionFactory;
+
+    public MainActivityAppCompatDelegate(
+            @NonNull Activity activity,
+            @NonNull InflationInjectFactory factory) {
+        this.context = activity;
+        this.originalDelegate = new AppCompatDelegateImpl(activity, activity.getWindow(), null);
+        this.inflationInjectionFactory = factory;
+    }
+
+    @Nullable
+    @Override
+    public ActionBar getSupportActionBar() {
+        return originalDelegate.getSupportActionBar();
+    }
+
+    @Override
+    public void setSupportActionBar(@Nullable final Toolbar toolbar) {
+        originalDelegate.setSupportActionBar(toolbar);
+    }
+
+    @Override
+    public MenuInflater getMenuInflater() {
+        return originalDelegate.getMenuInflater();
+    }
+
+    @Override
+    public void onCreate(final Bundle bundle) {
+        originalDelegate.onCreate(bundle);
+    }
+
+    @Override
+    public void onPostCreate(final Bundle bundle) {
+        originalDelegate.onPostCreate(bundle);
+    }
+
+    @Override
+    public void onConfigurationChanged(final Configuration configuration) {
+        originalDelegate.onConfigurationChanged(configuration);
+    }
+
+    @Override
+    public void onStart() {
+        originalDelegate.onStart();
+    }
+
+    @Override
+    public void onStop() {
+        originalDelegate.onStop();
+    }
+
+    @Override
+    public void onPostResume() {
+        originalDelegate.onPostResume();
+    }
+
+    @Nullable
+    @Override
+    public <T extends View> T findViewById(final int i) {
+        return originalDelegate.findViewById(i);
+    }
+
+    @Override
+    public void setContentView(final View view) {
+        originalDelegate.setContentView(view);
+    }
+
+    @Override
+    public void setContentView(final int i) {
+        originalDelegate.setContentView(i);
+    }
+
+    @Override
+    public void setContentView(final View view, final ViewGroup.LayoutParams layoutParams) {
+        originalDelegate.setContentView(view, layoutParams);
+    }
+
+    @Override
+    public void addContentView(final View view, final ViewGroup.LayoutParams layoutParams) {
+        originalDelegate.addContentView(view, layoutParams);
+    }
+
+    @Override
+    public void setTitle(@Nullable final CharSequence charSequence) {
+        originalDelegate.setTitle(charSequence);
+    }
+
+    @Override
+    public void invalidateOptionsMenu() {
+        originalDelegate.invalidateOptionsMenu();
+    }
+
+    @Override
+    public void onDestroy() {
+        originalDelegate.onDestroy();
+    }
+
+    @Nullable
+    @Override
+    public ActionBarDrawerToggle.Delegate getDrawerToggleDelegate() {
+        return originalDelegate.getDrawerToggleDelegate();
+    }
+
+    @Override
+    public boolean requestWindowFeature(final int i) {
+        return originalDelegate.requestWindowFeature(i);
+    }
+
+    @Override
+    public boolean hasWindowFeature(final int i) {
+        return originalDelegate.hasWindowFeature(i);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback) {
+        return originalDelegate.startSupportActionMode(callback);
+    }
+
+    @Override
+    public void installViewFactory() {
+        final LayoutInflater layoutInflater = LayoutInflater.from(context);
+        layoutInflater.setFactory2(this);
+    }
+
+    @Override
+    public View createView(@Nullable final View view, final String s,
+                           @NonNull final Context context,
+                           @NonNull final AttributeSet attributeSet) {
+        return originalDelegate.createView(view, s, context, attributeSet);
+    }
+
+    @Override
+    public void setHandleNativeActionModesEnabled(final boolean b) {
+        originalDelegate.setHandleNativeActionModesEnabled(b);
+    }
+
+    @Override
+    public boolean isHandleNativeActionModesEnabled() {
+        return originalDelegate.isHandleNativeActionModesEnabled();
+    }
+
+    @Override
+    public void onSaveInstanceState(final Bundle bundle) {
+        originalDelegate.onSaveInstanceState(bundle);
+    }
+
+    @Override
+    public boolean applyDayNight() {
+        return originalDelegate.applyDayNight();
+    }
+
+    @Override
+    public void setLocalNightMode(final int i) {
+        originalDelegate.setLocalNightMode(i);
+    }
+
+    @Override
+    public View onCreateView(View view, final String s, final Context context,
+                             final AttributeSet attributeSet) {
+        final View delegateView = this.originalDelegate.createView(view, s, context, attributeSet);
+        if (delegateView == null) {
+            return inflationInjectionFactory.onCreateView(view, s, context, attributeSet);
+        }
+        return delegateView;
+    }
+
+    @Override
+    public View onCreateView(final String s, final Context context,
+                             final AttributeSet attributeSet) {
+        final View delegateView = this.originalDelegate.createView(null, s, context, attributeSet);
+        if (delegateView == null) {
+            return inflationInjectionFactory.onCreateView(null, s, context, attributeSet);
+        }
+        return delegateView;
+    }
+
+
+}

--- a/inflation-inject-sample/src/main/java/com/example/MainActivity.java
+++ b/inflation-inject-sample/src/main/java/com/example/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import com.squareup.inject.inflation.InflationInjectFactory;
 import dagger.Component;
@@ -13,6 +14,9 @@ public final class MainActivity extends Activity {
     getLayoutInflater().setFactory(factory);
 
     setContentView(R.layout.custom_view);
+
+    findViewById(R.id.openAppCompat)
+            .setOnClickListener((view) -> startActivity(new Intent(this, MainActivityAppCompat.class)));
   }
 
   @Component(modules = ViewModule.class)

--- a/inflation-inject-sample/src/main/java/com/example/MainActivityAppCompat.java
+++ b/inflation-inject-sample/src/main/java/com/example/MainActivityAppCompat.java
@@ -1,0 +1,41 @@
+package com.example;
+
+import com.squareup.inject.inflation.InflationInjectFactory;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.app.MainActivityAppCompatDelegate;
+import android.view.View;
+
+import dagger.Component;
+
+public final class MainActivityAppCompat extends AppCompatActivity {
+    private MainAppCompatComponent mainComponent;
+
+    private AppCompatDelegate appCompatDelegate;
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        mainComponent = DaggerMainActivityAppCompat_MainAppCompatComponent.create();
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.custom_view);
+
+        findViewById(R.id.openAppCompat).setVisibility(View.GONE);
+    }
+
+    @NonNull
+    @Override
+    public AppCompatDelegate getDelegate() {
+        if (appCompatDelegate == null) {
+            appCompatDelegate = new MainActivityAppCompatDelegate(this, mainComponent.factory());
+        }
+        return appCompatDelegate;
+    }
+
+    @Component(modules = ViewModule.class)
+    interface MainAppCompatComponent {
+        InflationInjectFactory factory();
+    }
+}

--- a/inflation-inject-sample/src/main/res/layout/custom_view.xml
+++ b/inflation-inject-sample/src/main/res/layout/custom_view.xml
@@ -18,6 +18,13 @@
       android:layout_marginTop="8dp"
       android:hint="Show"
       />
+    <Button
+            android:id="@+id/openAppCompat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="Open AppCompat Activity"
+    />
   <TextView
       android:id="@+id/output"
       android:layout_width="match_parent"


### PR DESCRIPTION
I was struggling with the same problem stated in #69, so I thought it would be a good idea to share my approach with the community and ideally merge it. If you don't like that approach I will gladly close this PR.

The key is in `MainActivityAppCompatDelegate` which I put under the `android.support.v7.app` package to be able to access the default constructor that was marked as package-private.