### PR TITLE
Include factories found in previous processing rounds when generating modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.3.20',
+      'kotlin': '1.2.71',
   ]
 
   ext.deps = [
@@ -23,7 +23,7 @@ buildscript {
 
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-    classpath 'com.android.tools.build:gradle:3.3.2'
+    classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
   }
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.2.71',
+      'kotlin': '1.3.20',
   ]
 
   ext.deps = [
@@ -23,7 +23,7 @@ buildscript {
 
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-    classpath 'com.android.tools.build:gradle:3.3.0-alpha13'
+    classpath 'com.android.tools.build:gradle:3.3.2'
   }
 
   repositories {


### PR DESCRIPTION
Background:

At work we've got an annotation processor that helps us with a bunch of boilerplate for feature modules (mostly dagger related things). We've recently introduced AssistedInject, and I want to generate the `@AssistedModule` module too. 

Problem: 

Since our `@AssistedModule` is generated in the 1st processing round, it is only processed in the 2nd. In the 2nd processing round, none of our `AssistedInject.Factory` factories are included in that round. As a result, the generated module has no bindings 0️⃣ 

Change:

Adds a list to track all previously discovered factories, then pass them all to the assisted module once it's found. In the typical case, nothing changes. 