### PR TITLE
Allow duplicate provided bindings

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
@@ -224,14 +224,6 @@ class AssistedInjectProcessor : AbstractProcessor() {
     if (providedRequests.isEmpty()) {
       warn("Assisted injection without at least one non-@Assisted parameter doesn't need a factory",
           targetConstructor)
-    } else {
-      val providedDuplicates = providedRequests.groupBy { it.key }.filterValues { it.size > 1 }
-      if (providedDuplicates.isNotEmpty()) {
-        error("Duplicate non-@Assisted parameters declared. Forget a qualifier annotation?"
-            + providedDuplicates.values.flatten().joinToString("\n * ", prefix = "\n * "),
-            targetConstructor)
-        valid = false
-      }
     }
 
     // Project the factory method (which may have come from a supertype) as if it were a member of

--- a/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
+++ b/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
@@ -249,16 +249,37 @@ class AssistedInjectProcessorTest {
       }
     """)
 
+    val expected = JavaFileObjects.forSourceString("test.Test_AssistedFactory", """
+      package test;
+
+      import java.lang.Override;
+      import java.lang.String;
+      import $GENERATED_TYPE;
+      import javax.inject.Inject;
+      import javax.inject.Provider;
+
+      $GENERATED_ANNOTATION
+      public final class Test_AssistedFactory implements Test.Factory {
+        private final Provider<String> foo;
+        private final Provider<String> baz;
+
+        @Inject public Test_AssistedFactory(Provider<String> foo, Provider<String> baz) {
+          this.foo = foo;
+          this.baz = baz;
+        }
+
+        @Override public Test create(String bar) {
+          return new Test(foo.get(), bar, baz.get());
+        }
+      }
+    """)
+
     assertAbout(javaSource())
         .that(input)
         .processedWith(AssistedInjectProcessor())
-        .failsToCompile()
-        .withErrorContaining("""
-          Duplicate non-@Assisted parameters declared. Forget a qualifier annotation?
-             * java.lang.String foo
-             * java.lang.String baz
-        """.trimIndent())
-        .`in`(input).onLine(9)
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected)
   }
 
   @Test fun duplicateAssisted() {


### PR DESCRIPTION
Dagger allows this so there's no reason for us to be more strict than it.

Closes #91.