### PR TITLE
Explicitly sort module bind methods

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -6,7 +6,7 @@
 # http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 SLUG="square/AssistedInject"
-JDK="oraclejdk8"
+JDK="openjdk8"
 BRANCH="master"
 
 set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - mkdir "$ANDROID_HOME/licenses" || true

--- a/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2Processor.kt
+++ b/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2Processor.kt
@@ -32,6 +32,7 @@ import com.squareup.inject.assisted.processor.internal.toTypeName
 import com.squareup.javapoet.JavaFile
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
 import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.AGGREGATING
+import java.util.TreeMap
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Filer
 import javax.annotation.processing.Messager
@@ -88,8 +89,8 @@ class AssistedInjectDagger2Processor : AbstractProcessor() {
       } else {
         userModule = moduleType.qualifiedName.toString()
 
-        val assistedInjectionModule = assistedModuleElements.toInflationInjectionModule()
-        writeInflationModule(assistedModuleElements, assistedInjectionModule)
+        val assistedInjectionModule = assistedModuleElements.toAssistedInjectionModule()
+        writeAssistedModule(assistedModuleElements, assistedInjectionModule)
       }
     }
 
@@ -99,7 +100,7 @@ class AssistedInjectDagger2Processor : AbstractProcessor() {
       val userModuleFqcn = userModule
       if (userModuleFqcn != null) {
         // In the processing round in which we handle the @AssistedModule the @Module annotation's
-        // includes contain an <error> type because we haven't generated the inflation module yet.
+        // includes contain an <error> type because we haven't generated the assisted module yet.
         // As a result, we need to re-lookup the element so that its referenced types are available.
         val userModule = elements.getTypeElement(userModuleFqcn)
 
@@ -150,18 +151,18 @@ class AssistedInjectDagger2Processor : AbstractProcessor() {
     return AssistedModuleElements(assistedModule, factoryTypeElements)
   }
 
-  private fun AssistedModuleElements.toInflationInjectionModule(): AssistedInjectionModule {
+  private fun AssistedModuleElements.toAssistedInjectionModule(): AssistedInjectionModule {
     val moduleName = moduleType.toClassName()
     val targetNameToFactoryNames = targetTypeToFactoryType
         .map { (target, factory) -> target.asType().toTypeName() to factory.toClassName() }
-        .toMap()
+        .toMap(TreeMap())
     val public = Modifier.PUBLIC in moduleType.modifiers
     val generatedAnnotation = createGeneratedAnnotation(elements)
     return AssistedInjectionModule(moduleName, public, targetNameToFactoryNames,
         generatedAnnotation)
   }
 
-  private fun writeInflationModule(
+  private fun writeAssistedModule(
     elements: AssistedModuleElements,
     module: AssistedInjectionModule
   ) {

--- a/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
+++ b/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.inject.assisted.dagger2.processor
 
+import com.google.common.collect.Collections2
 import com.google.common.truth.Truth.assertAbout
 import com.google.testing.compile.JavaFileObjects
 import com.google.testing.compile.JavaSourceSubjectFactory.javaSource
@@ -84,6 +85,96 @@ class AssistedInjectDagger2ProcessorTest {
         .compilesWithoutError()
         .and()
         .generatesSources(expected)
+  }
+
+  @Test fun moduleMethodsAreSorted() {
+    val one = JavaFileObjects.forSourceString("test.One", """
+      package test;
+
+      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.assisted.AssistedInject;
+
+      class One {
+        @AssistedInject
+        One(Long foo, @Assisted String bar) {}
+
+        @AssistedInject.Factory
+        interface Factory {}
+      }
+
+      class One_AssistedFactory implements One.Factory {}
+    """)
+    val two = JavaFileObjects.forSourceString("test.Two", """
+      package test;
+
+      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.assisted.AssistedInject;
+
+      class Two {
+        @AssistedInject
+        Two(Long foo, @Assisted String bar) {}
+
+        @AssistedInject.Factory
+        interface Factory {}
+      }
+
+      class Two_AssistedFactory implements Two.Factory {}
+    """)
+    val three = JavaFileObjects.forSourceString("test.Three", """
+      package test;
+
+      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.assisted.AssistedInject;
+
+      class Three {
+        @AssistedInject
+        Three(Long foo, @Assisted String bar) {}
+
+        @AssistedInject.Factory
+        interface Factory {}
+      }
+
+      class Three_AssistedFactory implements Three.Factory {}
+    """)
+    val module = JavaFileObjects.forSourceString("test.TestModule", """
+      package test;
+
+      import com.squareup.inject.assisted.dagger2.AssistedModule;
+      import dagger.Module;
+
+      @AssistedModule
+      @Module(includes = AssistedInject_TestModule.class)
+      abstract class TestModule {}
+    """)
+
+    val expected = JavaFileObjects.forSourceString("test.AssistedInject_TestModule", """
+      package test;
+
+      import dagger.Binds;
+      import dagger.Module;
+      import $GENERATED_TYPE;
+
+      @Module
+      $GENERATED_ANNOTATION
+      abstract class AssistedInject_TestModule {
+        private AssistedInject_TestModule() {}
+
+        @Binds abstract One.Factory bind_test_One(One_AssistedFactory factory);
+
+        @Binds abstract Three.Factory bind_test_Three(Three_AssistedFactory factory);
+
+        @Binds abstract Two.Factory bind_test_Two(Two_AssistedFactory factory);
+      }
+    """)
+
+    for (items in Collections2.permutations(listOf(one, two, three))) {
+      assertAbout(javaSources())
+          .that(items + module)
+          .processedWith(AssistedInjectDagger2Processor())
+          .compilesWithoutError()
+          .and()
+          .generatesSources(expected)
+    }
   }
 
   @Test fun public() {


### PR DESCRIPTION
This will order the module based on the target type name so that it is stable across invocations.

Closes #102