### PR TITLE
Use the same name for each @Binds method

### DIFF
--- a/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectionModule.kt
+++ b/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectionModule.kt
@@ -42,7 +42,7 @@ data class AssistedInjectionModule(
             .build())
         .applyEach(targetNameToFactoryName) { targetName, factoryName ->
           val rawTargetName = targetName.rawClassName()
-          addMethod(MethodSpec.methodBuilder(rawTargetName.bindMethodName())
+          addMethod(MethodSpec.methodBuilder("generatedFactory")
               .addAnnotation(BINDS)
               .addModifiers(ABSTRACT)
               .returns(factoryName)
@@ -52,8 +52,6 @@ data class AssistedInjectionModule(
         .build()
   }
 }
-
-private fun ClassName.bindMethodName() = "bind_" + reflectionName().replace('.', '_')
 
 fun ClassName.assistedInjectModuleName(): ClassName = peerClass("AssistedInject_" + simpleName())
 

--- a/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
+++ b/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
@@ -75,7 +75,7 @@ class AssistedInjectDagger2ProcessorTest {
       abstract class AssistedInject_TestModule {
         private AssistedInject_TestModule() {}
 
-        @Binds abstract Test.Factory bind_test_Test(Test_AssistedFactory factory);
+        @Binds abstract Test.Factory generatedFactory(Test_AssistedFactory factory);
       }
     """)
 
@@ -159,11 +159,9 @@ class AssistedInjectDagger2ProcessorTest {
       abstract class AssistedInject_TestModule {
         private AssistedInject_TestModule() {}
 
-        @Binds abstract One.Factory bind_test_One(One_AssistedFactory factory);
-
-        @Binds abstract Three.Factory bind_test_Three(Three_AssistedFactory factory);
-
-        @Binds abstract Two.Factory bind_test_Two(Two_AssistedFactory factory);
+        @Binds abstract One.Factory generatedFactory(One_AssistedFactory factory);
+        @Binds abstract Three.Factory generatedFactory(Three_AssistedFactory factory);
+        @Binds abstract Two.Factory generatedFactory(Two_AssistedFactory factory);
       }
     """)
 
@@ -220,7 +218,7 @@ class AssistedInjectDagger2ProcessorTest {
       public abstract class AssistedInject_TestModule {
         private AssistedInject_TestModule() {}
 
-        @Binds abstract Test.Factory bind_test_Test(Test_AssistedFactory factory);
+        @Binds abstract Test.Factory generatedFactory(Test_AssistedFactory factory);
       }
     """)
 
@@ -277,7 +275,7 @@ class AssistedInjectDagger2ProcessorTest {
       public abstract class AssistedInject_TestModule {
         private AssistedInject_TestModule() {}
 
-        @Binds abstract Outer.Test.Factory bind_test_Outer${'$'}Test(Outer${'$'}Test_AssistedFactory factory);
+        @Binds abstract Outer.Test.Factory generatedFactory(Outer${'$'}Test_AssistedFactory factory);
       }
     """)
 
@@ -332,7 +330,7 @@ class AssistedInjectDagger2ProcessorTest {
       public abstract class AssistedInject_TestModule {
         private AssistedInject_TestModule() {}
 
-        @Binds abstract Test.Factory bind_test_Test(Test_AssistedFactory factory);
+        @Binds abstract Test.Factory generatedFactory(Test_AssistedFactory factory);
       }
     """)
 


### PR DESCRIPTION
The parameter type is guaranteed to be different allowing these to be overloads. As a bonus, this reduces the bytecode size since they all share the same name now.