### PR TITLE
Support nested module types

### DIFF
--- a/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectionModule.kt
+++ b/assisted-inject-processor-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectionModule.kt
@@ -53,7 +53,9 @@ data class AssistedInjectionModule(
   }
 }
 
-fun ClassName.assistedInjectModuleName(): ClassName = peerClass("AssistedInject_" + simpleName())
+fun ClassName.assistedInjectModuleName(): ClassName {
+  return ClassName.get(packageName(), simpleNames().joinToString("_", prefix = "AssistedInject_"))
+}
 
 private inline fun <T : Any, K, V> T.applyEach(items: Map<K, V>, func: T.(K, V) -> Unit): T {
   items.forEach { (key, value) -> func(key, value) }

--- a/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
+++ b/assisted-inject-processor-dagger2/src/test/java/com/squareup/inject/assisted/dagger2/processor/AssistedInjectDagger2ProcessorTest.kt
@@ -366,7 +366,6 @@ class AssistedInjectDagger2ProcessorTest {
         .`in`(moduleOne).onLine(7)
   }
 
-  @Ignore("Not working!")
   @Test fun nestedModule() {
     val test = JavaFileObjects.forSourceString("test.Test", """
       package test;
@@ -408,7 +407,7 @@ class AssistedInjectDagger2ProcessorTest {
       public abstract class AssistedInject_Outer_TestModule {
         private AssistedInject_Outer_TestModule() {}
 
-        @Binds abstract Test.Factory bind_test_Test(Test_AssistedFactory factory);
+        @Binds abstract Test.Factory generatedFactory(Test_AssistedFactory factory);
       }
     """)
 


### PR DESCRIPTION
This uses a similar naming scheme to AutoValue and Dagger where the enclosing types must be listed.

Closes #108. Closes #109.