### PR TITLE
Change retention policy to support incremental annotation processing

### DIFF
--- a/assisted-inject-annotations-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/AssistedModule.java
+++ b/assisted-inject-annotations-dagger2/src/main/java/com/squareup/inject/assisted/dagger2/AssistedModule.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
-@Target(TYPE) @Retention(SOURCE)
+@Target(TYPE) @Retention(CLASS)
 public @interface AssistedModule {
 }

--- a/assisted-inject-annotations/src/main/java/com/squareup/inject/assisted/Assisted.java
+++ b/assisted-inject-annotations/src/main/java/com/squareup/inject/assisted/Assisted.java
@@ -19,8 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
-@Target(PARAMETER) @Retention(SOURCE)
+@Target(PARAMETER) @Retention(CLASS)
 public @interface Assisted {
 }

--- a/assisted-inject-annotations/src/main/java/com/squareup/inject/assisted/AssistedInject.java
+++ b/assisted-inject-annotations/src/main/java/com/squareup/inject/assisted/AssistedInject.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
  * Identifies a constructor participating in assisted injection.
@@ -43,9 +43,9 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
  * single method that returns the enclosing type and arguments which match the assisted arguments
  * of the enclosing {@code @AssistedInject}-annotated constructor.
  */
-@Target(CONSTRUCTOR) @Retention(SOURCE)
+@Target(CONSTRUCTOR) @Retention(CLASS)
 public @interface AssistedInject {
-  @Target(TYPE) @Retention(SOURCE)
+  @Target(TYPE) @Retention(CLASS)
   @interface Factory {
   }
 }

--- a/inflation-inject/src/main/java/com/squareup/inject/inflation/InflationInject.java
+++ b/inflation-inject/src/main/java/com/squareup/inject/inflation/InflationInject.java
@@ -4,9 +4,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
-@Retention(SOURCE)
+@Retention(CLASS)
 @Target(CONSTRUCTOR)
 public @interface InflationInject {
 }

--- a/inflation-inject/src/main/java/com/squareup/inject/inflation/InflationModule.java
+++ b/inflation-inject/src/main/java/com/squareup/inject/inflation/InflationModule.java
@@ -4,9 +4,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 
 @Target(TYPE)
-@Retention(SOURCE)
+@Retention(CLASS)
 public @interface InflationModule {
 }


### PR DESCRIPTION
Aggregating annotation processors require annotations to have either
CLASS or RUNTIME as retention policy.