### PR TITLE
Fix #147

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
@@ -85,9 +85,12 @@ class AssistedInjectProcessor : AbstractProcessor() {
 
     val assistedMethods = roundEnv.findElementsAnnotatedWith<Assisted>()
         .map { it.enclosingElement as ExecutableElement }
-    // Error any non-constructor usage of @Assisted.
+    // Error any non-constructor usage of @Assisted. Methods called "copy" are also excluded due to the generated
+    // for Kotlin data classes having their parameters carry the annotations from their counterparts in the primary
+    // constructor
     assistedMethods
         .filterNot { it.simpleName.contentEquals("<init>") }
+        .filterNot { it.simpleName.contentEquals("copy") }
         .forEach {
           error("@Assisted is only supported on constructor parameters", it)
         }

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
@@ -87,7 +87,7 @@ class AssistedInjectProcessor : AbstractProcessor() {
         .map { it.enclosingElement as ExecutableElement }
     // Error any non-constructor usage of @Assisted. Methods called "copy" are also excluded due to the generated
     // for Kotlin data classes having their parameters carry the annotations from their counterparts in the primary
-    // constructor
+    // constructor.
     assistedMethods
         .filterNot { it.simpleName.contentEquals("<init>") }
         .filterNot { it.simpleName.contentEquals("copy") }

--- a/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
+++ b/assisted-inject-processor/src/test/java/com/squareup/inject/assisted/processor/AssistedInjectProcessorTest.kt
@@ -1743,7 +1743,7 @@ class AssistedInjectProcessorTest {
         .`in`(input).onLine(12)
   }
 
-  @Test fun assistedFailsIfUsedOnRegularMethod() {
+  @Test fun assistedFailsIfUsedOnRegularMethodNotCalledCopy() {
     val input = JavaFileObjects.forSourceString("test.Test", """
       package test;
 
@@ -1760,6 +1760,61 @@ class AssistedInjectProcessorTest {
         .failsToCompile()
         .withErrorContaining("@Assisted is only supported on constructor parameters")
         .`in`(input).onLine(7)
+  }
+
+  @Test fun assistedIsAllowedOnMethodCalledCopy() {
+    val input = JavaFileObjects.forSourceString("test.Test", """
+      package test;
+      
+      public final class Test {
+        @com.squareup.inject.assisted.AssistedInject()
+        public Test(@com.squareup.inject.assisted.Assisted()
+        java.lang.String foo) {
+          super();
+        }
+        
+        public final test.Test copy(@com.squareup.inject.assisted.Assisted()
+        java.lang.String foo) {
+          return null;
+        }
+        
+        @com.squareup.inject.assisted.AssistedInject.Factory()
+        public static abstract interface Factory {
+          @org.jetbrains.annotations.NotNull()
+          public abstract test.Test create(@org.jetbrains.annotations.NotNull()
+          java.lang.String foo);
+        }
+      }
+    """)
+
+    val expected = JavaFileObjects.forSourceString("test.Test_AssistedFactory", """
+      package test;
+      
+      import java.lang.Override;
+      import java.lang.String;
+      import $GENERATED_TYPE;
+      import javax.inject.Inject;
+      
+      $GENERATED_ANNOTATION
+      public final class Test_AssistedFactory implements Test.Factory {
+        @Inject
+        public Test_AssistedFactory() {
+        }
+      
+        @Override
+        public Test create(String foo) {
+          return new Test(
+              foo);
+        }
+      }
+    """)
+
+    assertAbout(javaSource())
+        .that(input)
+        .processedWith(AssistedInjectProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected)
   }
 
   @Test fun assistedFailsIfUsedOnBareConstructor() {


### PR DESCRIPTION
I didn't use the exact stub generated for the data as it contained a lot of clutter that didn't seem useful. I also updated the name of the test that checks for `@Assisted` being used in non-constructor methods as otherwise I thought there could be a bit of a confusing overlap between this and the new one. 
