### PR TITLE
Copy dagger.* annotations from factory interface to implementation

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjection.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjection.kt
@@ -18,6 +18,7 @@ import javax.lang.model.element.Modifier.PUBLIC
 
 private val JAVAX_INJECT = ClassName.get("javax.inject", "Inject")
 private val JAVAX_PROVIDER = ClassName.get("javax.inject", "Provider")
+private const val PACKAGE_DAGGER = "dagger"
 
 /** The structure of an assisted injection factory. */
 data class AssistedInjection(
@@ -27,6 +28,8 @@ data class AssistedInjection(
   val dependencyRequests: List<DependencyRequest>,
   /** The factory interface type. */
   val factoryType: TypeName,
+  /** The annotations affecting the factory type. */
+  val factoryTypeAnnotations: Iterable<AnnotationSpec>,
   /** Name of the factory's only method. */
   val factoryMethod: String,
   /** The factory method return type. [targetType] must be assignable to this type. */
@@ -67,6 +70,9 @@ data class AssistedInjection(
             addAnnotation(generatedAnnotation)
           }
         }
+        .addAnnotations(factoryTypeAnnotations.filter {
+          it.type.rawClassName().packageName()?.run { contentEquals(PACKAGE_DAGGER) } ?: false
+        })
         .applyEach(providedKeys) {
           addField(it.providerType.withoutAnnotations(), it.name, PRIVATE, FINAL)
         }

--- a/assisted-inject-processor/src/test/java/dagger/TestAnnotation.kt
+++ b/assisted-inject-processor/src/test/java/dagger/TestAnnotation.kt
@@ -1,0 +1,3 @@
+package dagger
+
+internal annotation class TestAnnotation

--- a/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
+++ b/inflation-inject-processor/src/main/java/com/squareup/inject/inflation/processor/InflationInjectProcessor.kt
@@ -220,7 +220,7 @@ class InflationInjectProcessor : AbstractProcessor() {
 
     val targetType = targetType.asType().toTypeName()
     val generatedAnnotation = createGeneratedAnnotation(sourceVersion, elements)
-    return AssistedInjection(targetType, requests, FACTORY, "create", VIEW,
+    return AssistedInjection(targetType, requests, FACTORY, emptySet(), "create", VIEW,
         FACTORY_KEYS, generatedAnnotation)
   }
 


### PR DESCRIPTION
Proposal for #158 

I have mixed feelings about restricting this to dagger annotations only, but this covers my use case, and since allowing any annotation would also require a mechanism to opt-out of copying an annotation to the generated implementation, plus it isn't something that has even been discussed to begin with, I guess we could probably consider this enough for now.

I'm off to bed now, but I'll check any comments tomorrow morning!