### PR TITLE
Avoid wrapping a factory in a provider

### DIFF
--- a/assisted-inject-processor/build.gradle
+++ b/assisted-inject-processor/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   testImplementation deps.truth
   testImplementation deps.compileTesting
   testImplementation deps.inject
+  testImplementation deps.dagger
   if (!Jvm.current().javaVersion.isJava9Compatible()) {
     testImplementation files(Jvm.current().getToolsJar())
   }

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/javaPoet.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/internal/javaPoet.kt
@@ -1,9 +1,11 @@
 package com.squareup.inject.assisted.processor.internal
 
+import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
+import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.TypeMirror
 import kotlin.reflect.KClass
@@ -11,6 +13,8 @@ import kotlin.reflect.KClass
 fun TypeElement.toClassName(): ClassName = ClassName.get(this)
 fun TypeMirror.toTypeName(): TypeName = TypeName.get(this)
 fun KClass<*>.toClassName(): ClassName = ClassName.get(java)
+
+fun AnnotationMirror.toAnnotationSpec(): AnnotationSpec = AnnotationSpec.get(this)
 
 fun Iterable<CodeBlock>.joinToCode(separator: String = ", ") = CodeBlock.join(this, separator)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
       'kotlin': '1.3.41',
-      'dagger': '2.24',
+      'dagger': '2.33',
       'incap' : '0.2',
   ]
 


### PR DESCRIPTION
In the case of our own `@AssistedInject.Factory` or Dagger's `@AssistedFactory`, when used as a dependency request in another factory do not wrap it in a `Provider`. The factory is already stateless, so wrapping it in a stateless provider is pointless and wasteful. Moreover, Dagger's assisted injection implementation explicitly forbids this with an error.