### PR TITLE
Migrate inflation inject to its own assisting annotation

### DIFF
--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/AssistedInjectProcessor.kt
@@ -224,7 +224,7 @@ class AssistedInjectProcessor : AbstractProcessor() {
   private fun AssistedInjectElements.toAssistedInjectionOrNull(): AssistedInjection? {
     var valid = true
 
-    val requests = targetConstructor.parameters.map { it.asDependencyRequest() }
+    val requests = targetConstructor.parameters.map { it.asDependencyRequest<Assisted>() }
     val (assistedRequests, providedRequests) = requests.partition { it.isAssisted }
     if (assistedRequests.isEmpty()) {
       warn("Assisted injection without at least one @Assisted parameter can use @Inject",

--- a/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/DependencyRequest.kt
+++ b/assisted-inject-processor/src/main/java/com/squareup/inject/assisted/processor/DependencyRequest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.inject.assisted.processor
 
-import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.processor.internal.hasAnnotation
 import javax.lang.model.element.VariableElement
 
@@ -29,5 +28,5 @@ data class DependencyRequest(
   override fun toString() = (if (isAssisted) "@Assisted " else "") + "$key $name"
 }
 
-fun VariableElement.asDependencyRequest() =
-    DependencyRequest(asKey(), hasAnnotation<Assisted>(), simpleName.toString())
+inline fun <reified T : Annotation> VariableElement.asDependencyRequest() =
+    DependencyRequest(asKey(), hasAnnotation<T>(), simpleName.toString())

--- a/inflation-inject-processor/build.gradle
+++ b/inflation-inject-processor/build.gradle
@@ -7,6 +7,8 @@ apply plugin: 'org.jetbrains.kotlin.kapt'
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+kapt.includeCompileClasspath = false
+
 dependencies {
   implementation project(':inflation-inject')
   implementation project(':assisted-inject-processor')

--- a/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
+++ b/inflation-inject-processor/src/test/java/com/squareup/inject/inflation/processor/InflationInjectProcessorTest.kt
@@ -29,12 +29,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -115,11 +115,12 @@ class InflationInjectProcessorTest {
       import android.view.View;
       import com.squareup.inject.assisted.Assisted;
       import com.squareup.inject.assisted.AssistedInject;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Other.Factory foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Other.Factory foo) {
           super(context, attrs);
         }
       }
@@ -207,12 +208,12 @@ class InflationInjectProcessorTest {
       import android.util.AttributeSet;
       import android.view.View;
       import dagger.assisted.AssistedFactory;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Other.Factory foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Other.Factory foo) {
           super(context, attrs);
         }
       }
@@ -298,12 +299,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -356,13 +357,13 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class Outer {
         static class TestView extends View {
           @InflationInject
-          TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+          TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
             super(context, attrs);
           }
         }
@@ -443,12 +444,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView<T> extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -528,12 +529,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(Long foo, @Assisted Context context, @Assisted AttributeSet attrs) {
+        TestView(Long foo, @Inflated Context context, @Inflated AttributeSet attrs) {
           super(context, attrs);
         }
       }
@@ -581,12 +582,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted AttributeSet attrs, @Assisted Context context, Long foo) {
+        TestView(@Inflated AttributeSet attrs, @Inflated Context context, Long foo) {
           super(context, attrs);
         }
       }
@@ -633,12 +634,12 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.util.AttributeSet;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView {
         @InflationInject
-        TestView(@Assisted AttributeSet attrs, @Assisted Context context, Long foo) {
+        TestView(@Inflated AttributeSet attrs, @Inflated Context context, Long foo) {
           super(context, attrs);
         }
       }
@@ -659,12 +660,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.widget.LinearLayout;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends LinearLayout {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -712,12 +713,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.widget.LinearLayout;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class LongView extends LinearLayout {
         @InflationInject
-        LongView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        LongView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -728,12 +729,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.widget.LinearLayout;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class StringView extends LongView {
         @InflationInject
-        StringView(@Assisted Context context, @Assisted AttributeSet attrs, String foo) {
+        StringView(@Inflated Context context, @Inflated AttributeSet attrs, String foo) {
           super(context, attrs, Long.parseLong(foo));
         }
       }
@@ -821,7 +822,7 @@ class InflationInjectProcessorTest {
         .processedWith(InflationInjectProcessor())
         .failsToCompile()
         .withErrorContaining("""
-          Inflation injection requires Context and AttributeSet @Assisted parameters.
+          Inflation injection requires Context and AttributeSet @Inflated parameters.
               Found:
                 []
               Expected:
@@ -837,12 +838,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, @Assisted String hey, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, @Inflated String hey, Long foo) {
           super(context, attrs);
         }
       }
@@ -853,7 +854,7 @@ class InflationInjectProcessorTest {
         .processedWith(InflationInjectProcessor())
         .failsToCompile()
         .withErrorContaining("""
-          Inflation injection requires Context and AttributeSet @Assisted parameters.
+          Inflation injection requires Context and AttributeSet @Inflated parameters.
               Found:
                 [android.content.Context, android.util.AttributeSet, java.lang.String]
               Expected:
@@ -868,12 +869,12 @@ class InflationInjectProcessorTest {
 
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated AttributeSet attrs, Long foo) {
           super(null, attrs);
         }
       }
@@ -884,7 +885,7 @@ class InflationInjectProcessorTest {
         .processedWith(InflationInjectProcessor())
         .failsToCompile()
         .withErrorContaining("""
-          Inflation injection requires Context and AttributeSet @Assisted parameters.
+          Inflation injection requires Context and AttributeSet @Inflated parameters.
               Found:
                 [android.util.AttributeSet]
               Expected:
@@ -899,12 +900,12 @@ class InflationInjectProcessorTest {
 
       import android.content.Context;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, Long foo) {
+        TestView(@Inflated Context context, Long foo) {
           super(context, null);
         }
       }
@@ -915,7 +916,7 @@ class InflationInjectProcessorTest {
         .processedWith(InflationInjectProcessor())
         .failsToCompile()
         .withErrorContaining("""
-          Inflation injection requires Context and AttributeSet @Assisted parameters.
+          Inflation injection requires Context and AttributeSet @Inflated parameters.
               Found:
                 [android.content.Context]
               Expected:
@@ -931,12 +932,12 @@ class InflationInjectProcessorTest {
       import android.content.Context;
       import android.util.AttributeSet;
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs) {
           super(context, attrs);
         }
       }
@@ -946,7 +947,7 @@ class InflationInjectProcessorTest {
         .that(inputView)
         .processedWith(InflationInjectProcessor())
         .compilesWithoutError()
-        .withWarningContaining("Inflation injection requires at least one non-@Assisted parameter.")
+        .withWarningContaining("Inflation injection requires at least one non-@Inflated parameter.")
         .`in`(inputView).onLine(12)
         // .and().generatesNoFiles()
   }
@@ -956,12 +957,12 @@ class InflationInjectProcessorTest {
       package test;
 
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        private TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        private TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
       }
@@ -980,13 +981,13 @@ class InflationInjectProcessorTest {
       package test;
 
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class Outer {
         private static class TestView extends View {
           @InflationInject
-          TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+          TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
             super(context, attrs);
           }
         }
@@ -1006,13 +1007,13 @@ class InflationInjectProcessorTest {
       package test;
 
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class Outer {
         class TestView extends View {
           @InflationInject
-          TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+          TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
             super(context, attrs);
           }
         }
@@ -1032,17 +1033,17 @@ class InflationInjectProcessorTest {
       package test;
 
       import android.view.View;
-      import com.squareup.inject.assisted.Assisted;
+      import com.squareup.inject.inflation.Inflated;
       import com.squareup.inject.inflation.InflationInject;
 
       class TestView extends View {
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, Long foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, Long foo) {
           super(context, attrs);
         }
 
         @InflationInject
-        TestView(@Assisted Context context, @Assisted AttributeSet attrs, String foo) {
+        TestView(@Inflated Context context, @Inflated AttributeSet attrs, String foo) {
           super(context, attrs);
         }
       }

--- a/inflation-inject-sample/src/main/java/com/example/CustomView.java
+++ b/inflation-inject-sample/src/main/java/com/example/CustomView.java
@@ -6,7 +6,7 @@ import android.util.AttributeSet;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import com.squareup.inject.assisted.Assisted;
+import com.squareup.inject.inflation.Inflated;
 import com.squareup.inject.inflation.InflationInject;
 
 @SuppressLint("ViewConstructor") // Created by Inflation Inject.
@@ -14,7 +14,7 @@ public final class CustomView extends LinearLayout {
   private final Greeter greeter;
 
   @InflationInject
-  public CustomView(@Assisted Context context, @Assisted AttributeSet attrs, Greeter greeter) {
+  public CustomView(@Inflated Context context, @Inflated AttributeSet attrs, Greeter greeter) {
     super(context, attrs);
     this.greeter = greeter;
   }

--- a/inflation-inject/build.gradle
+++ b/inflation-inject/build.gradle
@@ -9,8 +9,7 @@ dependencies {
   // Annotations are exposed as 'api' because Dagger wants to read the @NonNull annotation on the
   // @Inject constructor parameter if you are using its implicit binding.
   api deps.androidxAnnotations
-  implementation deps.inject
-  api project(':assisted-inject-annotations')
+  api deps.inject
 
   testImplementation deps.kotlin
   testImplementation deps.junit

--- a/inflation-inject/src/main/java/com/squareup/inject/inflation/Inflated.java
+++ b/inflation-inject/src/main/java/com/squareup/inject/inflation/Inflated.java
@@ -1,0 +1,12 @@
+package com.squareup.inject.inflation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Retention(CLASS)
+@Target(PARAMETER)
+public @interface Inflated {
+}


### PR DESCRIPTION
With Dagger's built-in assisted injection we'll be removing our own. But we cannot reuse Dagger's `@Assisted` for inflation inject since it validates all usages are within its own `@AsisstedInject`.